### PR TITLE
DOM Element handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,23 @@ Instead of a HTML string it's also possible to pass an ID selector:
 const { list, items } = fromHTML('#my-template')
 ```
 
+It's possible to pass an DOM Element too:
+
+```html
+<div id="my-element">
+  <ul ref="list">
+    <li ref="items[]">Jane</li>
+    <li ref="items[]">John</li>
+    <li ref="items[]">Jimmy</li>
+  </ul>
+</div>
+```
+
+```javascript
+// list and items are references to existing dom
+const { list, items } = fromHTML(document.getElementById('my-element'))
+```
+
 In the optional second argument the following options can be specified:
 
 - `refAttribute: String` -- the attribute to get the element references from; defaults to `ref`

--- a/src/from-html.js
+++ b/src/from-html.js
@@ -9,12 +9,19 @@ export default function fromHTML (html, {
   refAttribute: attr = 'ref',
   removeRefAttribute: remove = true
 } = {}) {
-  const container = document.createElement('div')
-  const elementId = html[0] === '#' && html.slice(1)
+  let container = null;
+  let elementId = null;
 
-  container.innerHTML = elementId
-    ? document.getElementById(elementId).innerHTML
-    : html
+  if(html instanceof window.Element) {
+    container = html;
+  } else {
+    container = document.createElement('div')
+    elementId = html[0] === '#' && html.slice(1)
+
+    container.innerHTML = elementId
+        ? document.getElementById(elementId).innerHTML
+        : html
+  }
 
   const refs = container.querySelectorAll(`[${attr}]`)
 

--- a/test/from-html.spec.js
+++ b/test/from-html.spec.js
@@ -50,6 +50,18 @@ describe('::fromHTML', () => {
 
       expect(foo instanceof window.HTMLElement).toBe(true)
     })
+
+    it('should work with passing an Element', () => {
+      document.body.innerHTML = `
+        <div id="my-element">
+          <div ref="foo"></div>
+        </div>
+      `
+
+      const { foo } = fromHTML(document.getElementById('my-element'))
+
+      expect(foo instanceof window.HTMLElement).toBe(true)
+    })
   })
 
   describe('options', () => {


### PR DESCRIPTION
Proposition for handling DOM Element as first argument for fromHTML. The only difference in that case is that the fromHTML returns references to DOM not new Elements.